### PR TITLE
MVP - Junkership/Trashbot Collisions

### DIFF
--- a/source/GameContainer.js
+++ b/source/GameContainer.js
@@ -1,0 +1,8 @@
+var Pixi = require("pixi.js")
+
+export default class GameContainer extends Pixi.Container {
+    constructor() {
+        super()
+        this.playerCount = 0
+    }
+}

--- a/source/Junkership.js
+++ b/source/Junkership.js
@@ -36,7 +36,8 @@ export default class Junkership extends Pixi.Sprite {
         console.log("Score: " + this.score)
     }
     onCollision(collidedWith) {
-        
+        game.removeChild(this)
+        this.destroy()
     }
 
 }

--- a/source/Junkership.js
+++ b/source/Junkership.js
@@ -11,6 +11,7 @@ export default class Junkership extends Pixi.Sprite {
         super(junkerTex)
         this.speed = 60
         this.score = 0
+        game.playerCount++
     }
     update(delta) {
         if(Keyb.isDown("<up>") && this.position.y > 0) {
@@ -38,6 +39,7 @@ export default class Junkership extends Pixi.Sprite {
     onCollision(collidedWith) {
         game.removeChild(this)
         this.destroy()
+        game.playerCount--
     }
 
 }

--- a/source/Trashbot.js
+++ b/source/Trashbot.js
@@ -20,15 +20,15 @@ export default class Trashbot extends Pixi.Sprite {
             this.position.x = Reference.GAME_WIDTH
         }
         var killedBy
-        game.children.forEach((toCompare) => {
-            if (toCompare instanceof Projectile) {
-                if (Utility.hasCollision(this, toCompare)) {
-                    killedBy = toCompare //
-                    toCompare.onCollision(this)
+        game.children.forEach((child) => {
+            if (child instanceof Projectile) {
+                if (Utility.hasCollision(this, child)) {
+                    killedBy = child
+                    child.onCollision(this)
                 }
-            } else if (toCompare instanceof Junkership) {
-                if (Utility.hasCollision(this, toCompare)) {
-                    toCompare.onCollision(this)
+            } else if (child instanceof Junkership) {
+                if (Utility.hasCollision(this, child)) {
+                    child.onCollision(this)
                 }
             }
         })

--- a/source/Trashbot.js
+++ b/source/Trashbot.js
@@ -3,6 +3,7 @@ var Utility = require("./Utility")
 
 import Reference from "./Reference.js"
 import Projectile from "./Projectile.js"
+import Junkership from "./Junkership.js"
 
 var trashbotTex = Pixi.Texture.fromImage(require("./images/enemy-starship.png"))
 
@@ -18,14 +19,22 @@ export default class Trashbot extends Pixi.Sprite {
         if (this.position.x + this.width < 0) {
             this.position.x = Reference.GAME_WIDTH
         }
+        var killedBy
         game.children.forEach((toCompare) => {
             if (toCompare instanceof Projectile) {
-                if(Utility.hasCollision(this, toCompare)) {
-                    this.onCollision(toCompare)
+                if (Utility.hasCollision(this, toCompare)) {
+                    killedBy = toCompare //
+                    toCompare.onCollision(this)
+                }
+            } else if (toCompare instanceof Junkership) {
+                if (Utility.hasCollision(this, toCompare)) {
                     toCompare.onCollision(this)
                 }
             }
         })
+        if (killedBy) {
+            this.onCollision(killedBy)
+        }
     }
 
     onCollision(collidedWith) {

--- a/source/Utility.js
+++ b/source/Utility.js
@@ -1,18 +1,22 @@
 exports.hasCollision = function hasCollision(a, b) {
-    var x1 = a.position.x
-    var y1 = a.position.y
-    var w1 = a.width
-    var h1 = a.height
-
-    var x2 = b.position.x
-    var y2 = b.position.y
-    var w2 = b.width
-    var h2 = b.height
-
-    if(x1 < x2 + w2 && x1 + w1 > x2
-    && y1 < y2 + h2 && h1 + y1 > y2) {
-        return true
-    } else {
+    if ( a == null || b == null) {
         return false
+    } else {
+        var x1 = a.position.x
+        var y1 = a.position.y
+        var w1 = a.width
+        var h1 = a.height
+
+        var x2 = b.position.x
+        var y2 = b.position.y
+        var w2 = b.width
+        var h2 = b.height
+
+        if(x1 < x2 + w2 && x1 + w1 > x2
+        && y1 < y2 + h2 && h1 + y1 > y2) {
+            return true
+        } else {
+            return false
+        }
     }
 }

--- a/source/index.js
+++ b/source/index.js
@@ -13,6 +13,7 @@ renderer.roundPixels = true
 
 document.getElementById("mount").appendChild(renderer.view)
 window.game = new Pixi.Container()
+game.playerCount = 0
 game.addChild(new Junkership())
 
 game.addChild(new Trashbot(Reference.GAME_WIDTH, Reference.GAME_HEIGHT/2))
@@ -21,5 +22,13 @@ var loop = new Afloop(function(delta) {
     game.children.forEach((child) => {
         child.update(delta)
     })
+    if (game.playerCount === 0) {
+        gameOver()
+    }
     renderer.render(game)
 })
+
+var gameOver = function () {
+    console.log("Respawning Junkership")
+    game.addChild(new Junkership())
+}

--- a/source/index.js
+++ b/source/index.js
@@ -6,14 +6,14 @@ import Junkership from "./Junkership.js"
 import Trashbot from "./Trashbot.js"
 import Reference from "./Reference.js"
 import Projectile from "./Projectile.js"
+import GameContainer from "./GameContainer.js"
 
 var renderer = Pixi.autoDetectRenderer(Reference.GAME_WIDTH, Reference.GAME_HEIGHT)
 renderer.backgroundColor = 0x222222
 renderer.roundPixels = true
 
 document.getElementById("mount").appendChild(renderer.view)
-window.game = new Pixi.Container()
-game.playerCount = 0
+window.game = new GameContainer()
 game.addChild(new Junkership())
 
 game.addChild(new Trashbot(Reference.GAME_WIDTH, Reference.GAME_HEIGHT/2))
@@ -23,12 +23,12 @@ var loop = new Afloop(function(delta) {
         child.update(delta)
     })
     if (game.playerCount === 0) {
-        gameOver()
+        game.gameOver()
     }
     renderer.render(game)
 })
 
-var gameOver = function () {
+game.gameOver = function () {
     console.log("Respawning Junkership")
     game.addChild(new Junkership())
 }


### PR DESCRIPTION
Closes #13, closes #14, closes #15: Junkerships collide with Trashbots, die, and trigger game over logic which currently simply respawns them.

Fixes #23: Trashbot was continuing to iterate through game.children after it died, leading to comparing itself (now null) to the other projectiles. Added null check to hasCollision and moved actual "death" of a Trashbot to outside the collision checking loop.

Playable build at http://mocsarcade.github.io/starjunk/v0.1.5/
