### PR TITLE
Player HitBox Shrunk - Includes change to texture loading

### DIFF
--- a/source/GameContainer.js
+++ b/source/GameContainer.js
@@ -3,11 +3,13 @@ var Pixi = require("pixi.js")
 import Junkership from "./Junkership.js"
 import Trashbot from "./Trashbot.js"
 import Reference from "./Reference.js"
+import Textures from "./Textures.js"
 
 export default class GameContainer extends Pixi.Container {
     constructor() {
         super()
         this.playerCount = 0
+        Textures.initTex()
     }
     gameOver() {
         console.log("Respawning Junkership")

--- a/source/Junkership.js
+++ b/source/Junkership.js
@@ -5,11 +5,9 @@ import Reference from "./Reference.js"
 import Projectile from "./Projectile.js"
 import Score from "./Score.js"
 
-var junkerTex = Pixi.Texture.fromImage(require("./images/blue-starship.png"))
-
 export default class Junkership extends Pixi.Sprite {
     constructor() {
-        super(junkerTex)
+        super(PIXI.loader.resources.redJunkership.texture)
         game.playerCount++
         this.speed = 60
         this.score = new Score()
@@ -19,8 +17,12 @@ export default class Junkership extends Pixi.Sprite {
 
     }
     update(delta) {
-        var relativeSpeed = this.speed * delta
+        // Ugly kludge
+        if (this.width === 1) {
+            this.onCollision()
+        }
 
+        var relativeSpeed = this.speed * delta
 
         if (Keyb.isJustDown("<up>")) {
             this.ignoreY = "down"

--- a/source/Junkership.js
+++ b/source/Junkership.js
@@ -13,6 +13,10 @@ export default class Junkership extends Pixi.Sprite {
         game.playerCount++
         this.speed = 60
         this.score = new Score()
+
+        this.hitBox = new Pixi.Rectangle( this.x + 1 , this.y + 1 ,
+            this.width - 3 , this.height - 3 )
+
     }
     update(delta) {
         var relativeSpeed = this.speed * delta
@@ -52,7 +56,6 @@ export default class Junkership extends Pixi.Sprite {
         if(Keyb.isJustDown("<space>")) {
             this.shoot()
         }
-
     }
     onCollision(collidedWith) {
         game.removeChild(this)
@@ -74,6 +77,9 @@ export default class Junkership extends Pixi.Sprite {
         }
 
         this.position[direction] = newPosition
+
+        this.hitBox.x = this.x + 1
+        this.hitBox.y = this.y + 1
     }
 
     shoot() {

--- a/source/Junkership.js
+++ b/source/Junkership.js
@@ -12,8 +12,11 @@ export default class Junkership extends Pixi.Sprite {
         this.speed = 60
         this.score = new Score()
 
-        this.hitBox = new Pixi.Rectangle( this.x + 1 , this.y + 1 ,
-            this.width - 3 , this.height - 3 )
+        this.hitBox = new Pixi.Rectangle(
+            this.x + 1 , // Left offset
+            this.y + 1 , // Top offset
+            this.width - 3 , // Right offset + left offset
+            this.height - 3 )// Bottom offset + top offset
 
     }
     update(delta) {

--- a/source/Projectile.js
+++ b/source/Projectile.js
@@ -1,18 +1,16 @@
 var Pixi = require("pixi.js")
 var Reference = require("Reference.js")
 
-var projectileTex = Pixi.Texture.fromImage(require("./images/projectile.png"))
-
 export default class Projectile extends Pixi.Sprite {
     constructor(x, y, shotBy) {
-        super(projectileTex)
+        super(PIXI.loader.resources.projectile.texture)
         this.x = x
         this.y = y
         this.speed = 80
         this.shotBy = shotBy
         console.log("Creating projectile")
     }
-    
+
     update(delta) {
         this.position.x += this.speed * delta
         if (this.position.x < 0 || this.position.x > Reference.GAME_WIDTH ||

--- a/source/Textures.js
+++ b/source/Textures.js
@@ -1,0 +1,20 @@
+var Pixi = require("pixi.js")
+
+import Junkership from "./Junkership.js"
+
+exports.initTex = function initTex() {
+    PIXI.loader
+        .add("redJunkership",    require("./images/red-starship.png"))
+        .add("yellowJunkership", require("./images/yellow-starship.png"))
+        .add("greenJunkership",  require("./images/green-starship.png"))
+        .add("blueJunkership",   require("./images/blue-starship.png"))
+        .add("projectile",       require("./images/projectile.png"))
+        .add("trashbot",         require("./images/enemy-starship.png"))
+        .load()
+
+        .on("complete",setup)
+}
+
+function setup() {
+    game.spawnWave()
+}

--- a/source/Textures.js
+++ b/source/Textures.js
@@ -1,7 +1,5 @@
 var Pixi = require("pixi.js")
 
-import Junkership from "./Junkership.js"
-
 exports.initTex = function initTex() {
     PIXI.loader
         .add("redJunkership",    require("./images/red-starship.png"))

--- a/source/Trashbot.js
+++ b/source/Trashbot.js
@@ -5,12 +5,10 @@ import Reference from "./Reference.js"
 import Projectile from "./Projectile.js"
 import Junkership from "./Junkership.js"
 
-var trashbotTex = Pixi.Texture.fromImage(require("./images/enemy-starship.png"))
-
 export default class Trashbot extends Pixi.Sprite {
     constructor(x, y) {
-        super(trashbotTex)
-        this.speed = 40
+        super(PIXI.loader.resources.trashbot.texture)
+        this.speed = 60
         this.position.x = x
         this.position.y = y
     }

--- a/source/Trashbot.js
+++ b/source/Trashbot.js
@@ -27,7 +27,7 @@ export default class Trashbot extends Pixi.Sprite {
                     child.onCollision(this)
                 }
             } else if (child instanceof Junkership) {
-                if (Utility.hasCollision(this, child)) {
+                if (Utility.hasCollision(this, child.hitBox)) {
                     child.onCollision(this)
                 }
             }

--- a/source/Utility.js
+++ b/source/Utility.js
@@ -2,13 +2,13 @@ exports.hasCollision = function hasCollision(a, b) {
     if ( a == null || b == null) {
         return false
     } else {
-        var x1 = a.position.x
-        var y1 = a.position.y
+        var x1 = a.x
+        var y1 = a.y
         var w1 = a.width
         var h1 = a.height
 
-        var x2 = b.position.x
-        var y2 = b.position.y
+        var x2 = b.x
+        var y2 = b.y
         var w2 = b.width
         var h2 = b.height
 

--- a/source/index.js
+++ b/source/index.js
@@ -6,7 +6,6 @@ import Junkership from "./Junkership.js"
 import Reference from "./Reference.js"
 import Score from "./Score.js"
 import GameContainer from "./GameContainer.js"
-import Textures from "./Textures.js"
 
 var renderer = Pixi.autoDetectRenderer(Reference.GAME_WIDTH, Reference.GAME_HEIGHT)
 renderer.backgroundColor = 0x222222
@@ -15,8 +14,6 @@ renderer.roundPixels = true
 var mount = document.getElementById("mount")
 mount.insertBefore(renderer.view, mount.firstChild)
 window.game = new GameContainer()
-
-Textures.initTex()
 
 var loop = new Afloop(function(delta) {
     game.children.forEach((child) => {

--- a/source/index.js
+++ b/source/index.js
@@ -3,11 +3,10 @@ var Afloop = require("afloop")
 var Keyb = require("keyb")
 
 import Junkership from "./Junkership.js"
-import Trashbot from "./Trashbot.js"
 import Reference from "./Reference.js"
-import Projectile from "./Projectile.js"
 import Score from "./Score.js"
 import GameContainer from "./GameContainer.js"
+import Textures from "./Textures.js"
 
 var renderer = Pixi.autoDetectRenderer(Reference.GAME_WIDTH, Reference.GAME_HEIGHT)
 renderer.backgroundColor = 0x222222
@@ -16,11 +15,8 @@ renderer.roundPixels = true
 var mount = document.getElementById("mount")
 mount.insertBefore(renderer.view, mount.firstChild)
 window.game = new GameContainer()
-Score.resetAll()
-game.addChild(new Junkership())
 
-game.spawnWave()
-
+Textures.initTex()
 
 var loop = new Afloop(function(delta) {
     game.children.forEach((child) => {


### PR DESCRIPTION
Closes #30; So! My attempts to create a smaller Junkership hitBox required either basing its size dynamically off the existing rectangle for the Junkership Sprite or hardcoding its size. Hardcoding things is generally a bad idea, but I found that the attributes the hitBox had to be based on weren't loading at the right time. Looking it up showed that we were using the "convenience" method of texture loading and we were sort of locked up as a result.

So I rewrote the texture loading to the preferred method, which fixed MOST of the problem. I've confirmed via testing in the console that the problem now fixes itself if we wait for a few frames to create the first Junkership. I could have hard-coded in a delay, but the best fix is going to be to have the Junkership spawn when its controls are activated, which we have to do anyway. That's getting a bit far afield, so I'd like to merge what I've got here first.

**As for the actual changes...** I made the default Junkership red, since that's the Player 1 color. This is good, because it revealed that the different shapes of the Junkerships makes them feel better with different hitBoxes. That seemed unbalancing though, so I went for a middle ground "best fit" option. I found that speeding up the bad guys also helped make the collision feel more "natural," but they may be a bit fast, considering it'll only speed up with rage mode.

Playable build at: http://mocsarcade.github.io/starjunk/hitBox/

Build using the blue ship to illustrate what I mean by the hitboxes feeling different: http://mocsarcade.github.io/starjunk/hitBox-blueShip/
