### PR TITLE
Fixed the build system to support production.

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -1,0 +1,10 @@
+var Electron = require("electron")
+
+Electron.app.on("ready", function() {
+    var window = new Electron.BrowserWindow({width: 512, height: 288})
+    window.loadURL("file://" + __dirname + "/builds/web/index.html")
+})
+
+Electron.app.on("window-all-closed", function() {
+    Electron.app.quit()
+})

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "contributors": [
     "Andrew McPherson <@ehgoodenough>",
-	"Skylar Rowan Lolmaugh <@binome>",
+    "Skylar Rowan Lolmaugh <@binome>",
     "Name <email/twitter/tumblr/whatever>"
   ],
   "dependencies": {
@@ -35,6 +35,8 @@
     "chalk": "^1.1.1",
     "css-loader": "^0.23.0",
     "cssesc": "^0.1.0",
+    "electron": "^0.4.1",
+    "electron-packager": "^5.2.1",
     "eslint": "^1.10.3",
     "eslint-loader": "^1.1.1",
     "extract-text-webpack-plugin": "^0.9.1",
@@ -54,16 +56,9 @@
     "yargs": "^3.31.0"
   },
   "engines": {
-    "node" : ">=0.12"
+    "node": ">=0.12"
   },
   "scripts": {
     "build": "node build"
-  },
-  "window": {
-      "title": "Starjunk",
-      "toolbar": false,
-      "width": 512,
-      "height": 288
-  },
-  "main": "index.html"
+  }
 }


### PR DESCRIPTION
Now `node build bundle --production` won't barf on you! The issue was UglifyJS was oversharing, so I just had to compress it's warnings.

If you're still having issues, hit me up.

[![selfie-1](http://i.imgur.com/6fzawBT.gif)](https://github.com/thieman/github-selfies/)
