### PR TITLE
Bugfix for collision between junk and junkership at edge of screen

### DIFF
--- a/source/Junk.js
+++ b/source/Junk.js
@@ -21,7 +21,7 @@ export default class Junk extends Pixi.Sprite {
         } else
             game.children.forEach((child) => {
                 if (child instanceof Junkership) {
-                    if (Utility.hasCollision(this, child.hitBox)) {
+                    if (Utility.hasCollision(this, child)) {
                         game.removeChild(this)
                         this.destroy()
                         child.score.incrementScore()


### PR DESCRIPTION
Closes #67 As per Skylar's note, changed the collision to the junkership sprite not its hitbox.  The issue should be fixed now.

Here's a playable build: http://mocsarcade.github.io/starjunk/68_bugfix/
