### PR TITLE
Spawn Wave Patterns

### DIFF
--- a/source/GameContainer.js
+++ b/source/GameContainer.js
@@ -1,12 +1,7 @@
 var Pixi = require("pixi.js")
 var Keyb = require("keyb")
-
 import Junkership from "./Junkership.js"
-import Trashbot from "./Trashbot.js"
-import SnakeTrashbot from "./SnakeTrashbot.js"
-import TankTrashbot from "./TankTrashbot.js"
-import SniperTrashbot from "./SniperTrashbot.js"
-import TurretTrashbot from "./TurretTrashbot.js"
+import SpawnWave from "./SpawnWave.js"
 import Reference from "./Reference.js"
 import Textures from "./Textures.js"
 import Junk from "./Junk.js"
@@ -17,6 +12,7 @@ export default class GameContainer extends Pixi.Container {
         super()
         this.countdownToJunk = Utility.randomNumber(Reference.JUNK_FREQUENCY_RANGE.lower, Reference.JUNK_FREQUENCY_RANGE.upper)
         this.spawnWaveInterval = 0
+        this.waves = []
         this.difficulty = Reference.DIFFICULTY[0]
         Textures.initTex()
     }
@@ -26,12 +22,10 @@ export default class GameContainer extends Pixi.Container {
     }
 
     spawnWave() {
-        if (Junkership.Inventory.length > 0) {
-            this.addChild(new SnakeTrashbot(new Pixi.Point(Reference.GAME_WIDTH, Reference.GAME_HEIGHT * 1/5), Trashbot.MovementStrategy.SINUSOIDAL))
-            this.addChild(new TankTrashbot(new Pixi.Point(Reference.GAME_WIDTH, Reference.GAME_HEIGHT * 2/5), Trashbot.MovementStrategy.LINEAR))
-            this.addChild(new SniperTrashbot(new Pixi.Point(Reference.GAME_WIDTH, Reference.GAME_HEIGHT * 3/5), Trashbot.MovementStrategy.MOVE_STOP,
-                SniperTrashbot.ShootStrategy.INTERVAL))
-            this.addChild(new TurretTrashbot(new Pixi.Point(Reference.GAME_WIDTH, Reference.GAME_HEIGHT * 4/5), Trashbot.ShootStrategy.RANDOM))
+        if (Junkership.Inventory.length > 0 && this.waves.length < game.difficulty.SPAWN_WAVE.MAX_WAVES) {
+            var height = Utility.randomNumber(1, game.difficulty.SPAWN_WAVE.MAX_HEIGHT)
+            var width = Utility.randomNumber(1, game.difficulty.SPAWN_WAVE.MAX_WIDTH)
+            this.waves.push(new SpawnWave(height, width))
         }
     }
 

--- a/source/Reference.js
+++ b/source/Reference.js
@@ -34,6 +34,12 @@ module.exports.TRASHBOT = {
 module.exports.DIFFICULTY = [
     {
         HEALTH_MULTIPLIER: 1,
-        SPAWN_INTERVAL: 5
+        SPAWN_WAVE: {
+            INTERVAL: 5,
+            MAX_HEIGHT: 6,
+            MAX_WIDTH: 7,
+            MAX_WAVES: 2
+        },
+
     }
 ]

--- a/source/SpawnWave.js
+++ b/source/SpawnWave.js
@@ -1,0 +1,115 @@
+var Pixi = require("pixi.js")
+import Reference from "./Reference.js"
+import Junkership from "./Junkership.js"
+import Utility from "./Utility.js"
+import Trashbot from "./Trashbot.js"
+import SnakeTrashbot from "./SnakeTrashbot.js"
+import TankTrashbot from "./TankTrashbot.js"
+import SniperTrashbot from "./SniperTrashbot.js"
+import TurretTrashbot from "./TurretTrashbot.js"
+var Move = Trashbot.MovementStrategy
+var Shoot = Trashbot.ShootStrategy
+
+
+export default class SpawnWave {
+    constructor(height, width) {
+        this.height = height
+        this.width = width
+        this.currentColumn = 0
+        this.transition = 0
+        this.emptyMatrix()
+        this.fillMatrix()
+        this.TRANSITION_LAPSE = 0.5
+    }
+
+    update(delta) {
+        this.transition += delta
+        if (this.currentColumn < this.width && this.transition >= this.TRANSITION_LAPSE) {
+            this.displayNextColumn(this.currentColumn)
+            this.currentColumn++
+            this.transition = 0
+        }
+
+        var column, row, empty = true
+        for (column = 0; column < this.width; column++) {
+            for (row = 0; row < this.height; row++) {
+                if (this.matrix[row][column] && "position" in this.matrix[row][column]) {
+                    empty = false
+                }
+            }
+        }
+        if (empty) {
+            game.waves.splice(game.waves.indexOf(this), 1)
+        }
+    }
+
+    emptyMatrix() {
+        this.matrix = []
+        for (var i = 0; i < this.height; i++) {
+            this.matrix[i] = new Array(this.width)
+        }
+    }
+
+    fillMatrix() {
+        var column, row
+        for (column = 0; column < this.width; column++) {
+            for (row = 0; row < this.height; row++) {
+                if (this.matrix[row][column] === undefined) {
+                    this.addPattern({x: column, y: row})
+                }
+            }
+        }
+    }
+
+    displayNextColumn(column) {
+        if (Junkership.Inventory.length > 0) {
+            var row
+            for (row = 0; row < this.matrix.length; row++) {
+                if (this.matrix[row][column]) {
+                    game.addChild(this.matrix[row][column])
+                }
+            }
+        }
+    }
+
+    addPattern(position) {
+        var random = Utility.randomNumber(0, SpawnWave.Patterns.length - 1)
+
+        var pattern = SpawnWave.Patterns[random]
+        var column, row
+        for (column = 0; column < pattern[0].length && column + position.x < this.width; column++) {
+            for (row = 0; row < pattern.length && row + position.y < this.height; row++) {
+                var screenPosition = new Pixi.Point(Reference.GAME_WIDTH, Reference.GAME_HEIGHT * (row + position.y + 1) / (this.height + 1))
+                var cell = pattern[row][column]
+                if (cell.type === null) {
+                    this.matrix[row + position.y][column + position.x] = null
+                } else if (cell.type === "Snake") {
+                    this.matrix[row + position.y][column + position.x] = new SnakeTrashbot(screenPosition, cell.movement)
+                } else if (cell.type === "Tank") {
+                    this.matrix[row + position.y][column + position.x] = new TankTrashbot(screenPosition, cell.movement)
+                } else if (cell.type === "Sniper") {
+                    this.matrix[row + position.y][column + position.x] = new SniperTrashbot(screenPosition, cell.movement, cell.shoot)
+                } else if (cell.type === "Turret") {
+                    this.matrix[row + position.y][column + position.x] = new TurretTrashbot(screenPosition, cell.shoot)
+                }
+            }
+        }
+
+    }
+}
+
+SpawnWave.Patterns = [
+    [
+        [{type: "Snake", movement: Move.SINUSOIDAL}, {type: "Snake", movement: Move.SINUSOIDAL}, {type: "Snake", movement: Move.SINUSOIDAL}]
+    ],
+    [
+        [{type: "Turret", shoot: Shoot.INTERVAL}, {type: null}]
+    ],
+    [
+        [{type: "Sniper", movement: Move.MOVE_STOP, shoot: Shoot.RANDOM}]
+    ],
+    [
+        [{type: "Tank", movement: Move.LINEAR}],
+        [{type: "Tank", movement: Move.LINEAR}]
+    ]
+]

--- a/source/Trashbot.js
+++ b/source/Trashbot.js
@@ -1,6 +1,5 @@
 var Pixi = require("pixi.js")
 var Utility = require("./Utility")
-
 import Reference from "./Reference.js"
 import Projectile from "./Projectile.js"
 import Junkership from "./Junkership.js"
@@ -58,6 +57,7 @@ export default class Trashbot extends Pixi.Sprite {
         game.removeChild(this)
         Trashbot.Inventory.splice(Trashbot.Inventory.indexOf(this), 1)
         super.destroy()
+        delete this.position
         game.untilJunk(finalPosition.x, finalPosition.y)
     }
 
@@ -117,7 +117,7 @@ Trashbot.ShootStrategy = {
         }
     },
     RANDOM: function(trashbot, period) {
-        var random = Utility.randomNumber(0, period / 2)
+        var random = Utility.randomNumber(0, period)
         if (random === 0) {
             var target = Junkership.Inventory[Utility.randomNumber(0, Junkership.Inventory.length - 1)]
             trashbot.fire(target)

--- a/source/index.js
+++ b/source/index.js
@@ -20,13 +20,16 @@ var loop = new Afloop(function(delta) {
     game.children.forEach((child) => {
         child.update(delta)
     })
+    game.waves.forEach((wave) => {
+        wave.update(delta)
+    })
     if (Junkership.Inventory.length < Reference.MAX_PLAYERS) {
         game.checkPlayerSpawn()
     }
     renderer.render(game)
 
     game.spawnWaveInterval += delta
-    if (game.spawnWaveInterval >= game.difficulty.SPAWN_INTERVAL) {
+    if (game.spawnWaveInterval >= game.difficulty.SPAWN_WAVE.INTERVAL) {
         game.spawnWave()
         game.spawnWaveInterval = 0
     }


### PR DESCRIPTION
Addresses #33 and #31 to create enemies that spawn in waves that are formed from random selection within a set patterns. Adds a bit more difficulty settings as well, to allow for easy tweaking of settings. The game still seems to be too broad in its difficulty, and one thing I'm thinking of implementing is choosing from different subsets of the patterns based on difficulty. Particularly, minimizing projectile-based enemies.
http://mocsarcade.github.io/starjunk/74/
