### PR TITLE
Difficulty tweaks

### DIFF
--- a/source/Controls.js
+++ b/source/Controls.js
@@ -100,7 +100,9 @@ export class padCont {
             return (game.gamepads[this.index].buttons[0].pressed ||
                     game.gamepads[this.index].buttons[1].pressed ||
                     game.gamepads[this.index].buttons[2].pressed ||
-                    game.gamepads[this.index].buttons[3].pressed)
+                    game.gamepads[this.index].buttons[3].pressed ||
+                    game.gamepads[this.index].buttons[5].pressed ||
+                    game.gamepads[this.index].buttons[7].pressed)
             break
         default:
             console.log("Invalid padCont isDown call: " + key)

--- a/source/Junkership.js
+++ b/source/Junkership.js
@@ -21,6 +21,8 @@ export default class Junkership extends Pixi.Sprite {
         this.powerUp = new PeaShoota()
         this.reloadTime = 0
         this.controls = cont
+        this.x = 10
+        this.y = Reference.GAME_HEIGHT / 2
         this.hitBox = new Pixi.Rectangle(
             this.x + 1 , // Left offset
             this.y + 1 , // Top offset

--- a/source/Junkership.js
+++ b/source/Junkership.js
@@ -16,7 +16,7 @@ export default class Junkership extends Pixi.Sprite {
     constructor(cont) {
         super(checkTex())
         Junkership.Inventory.push(this)
-        this.speed = 100
+        this.speed = 115
         this.score = new Score(Junkership.Inventory.length)
         this.powerUp = new PeaShoota()
         this.reloadTime = 0

--- a/source/Reference.js
+++ b/source/Reference.js
@@ -1,7 +1,7 @@
 module.exports.GAME_WIDTH = 400
 module.exports.GAME_HEIGHT = 225
 module.exports.JOIN_GAME_TEXT = "PRESS TO JOIN"
-module.exports.TIME_TO_DESPAWN = 5 * 1000
+module.exports.TIME_TO_DESPAWN = 7.5 * 1000
 module.exports.MAX_PLAYERS = 4
 module.exports.MAX_ENEMY_PROJECTILES = 25
 module.exports.NORMAL_BULLET_SPEED = 1.75
@@ -41,8 +41,8 @@ module.exports.DIFFICULTY = [
             PATTERNS_PER_WAVE: 1
         },
         JUNK_FREQUENCY_RANGE: {
-            lower: 4,
-            upper: 7
+            lower: 3,
+            upper: 5
         },
         SCORE_LIMIT: 3
     },

--- a/source/Reference.js
+++ b/source/Reference.js
@@ -4,8 +4,8 @@ module.exports.JOIN_GAME_TEXT = "PRESS TO JOIN"
 module.exports.TIME_TO_DESPAWN = 7.5 * 1000
 module.exports.MAX_PLAYERS = 4
 module.exports.MAX_ENEMY_PROJECTILES = 25
-module.exports.NORMAL_BULLET_SPEED = 1.75
-module.exports.FAST_BULLET_SPEED = 3
+module.exports.NORMAL_BULLET_SPEED = 2
+module.exports.FAST_BULLET_SPEED = 3.5
 module.exports.BG_VOLUME = 1
 module.exports.STAR_COUNT = 50
 module.exports.STAR_COLORS = [0xFFFF00, 0x00FFFF, 0x7FFF00] // Yellow Blue Green
@@ -41,13 +41,77 @@ module.exports.DIFFICULTY = [
             PATTERNS_PER_WAVE: 1
         },
         JUNK_FREQUENCY_RANGE: {
-            lower: 3,
-            upper: 5
+            lower: 4,
+            upper: 6
         },
         SCORE_LIMIT: 3
     },
     {
         LEVEL: 1,
+        HEALTH_MULTIPLIER: 1,
+        SPAWN_WAVE: {
+            INTERVAL: 1,
+            MAX_HEIGHT: 8,
+            MAX_WIDTH: 8,
+            MAX_WAVES: 10,
+            PATTERNS_PER_WAVE: 1
+        },
+        JUNK_FREQUENCY_RANGE: {
+            lower: 4,
+            upper: 6
+        },
+        SCORE_LIMIT: 10
+    },
+    {
+        LEVEL: 2,
+        HEALTH_MULTIPLIER: 1,
+        SPAWN_WAVE: {
+            INTERVAL: 1,
+            MAX_HEIGHT: 10,
+            MAX_WIDTH: 8,
+            MAX_WAVES: 12,
+            PATTERNS_PER_WAVE: 1
+        },
+        JUNK_FREQUENCY_RANGE: {
+            lower: 4,
+            upper: 5
+        },
+        SCORE_LIMIT: 20
+    },
+    {
+        LEVEL: 3,
+        HEALTH_MULTIPLIER: 1,
+        SPAWN_WAVE: {
+            INTERVAL: 1,
+            MAX_HEIGHT: 10,
+            MAX_WIDTH: 8,
+            MAX_WAVES: 8,
+            PATTERNS_PER_WAVE: 2
+        },
+        JUNK_FREQUENCY_RANGE: {
+            lower: 4,
+            upper: 5
+        },
+        SCORE_LIMIT: 30
+    },
+    {
+        LEVEL: 3,
+        HEALTH_MULTIPLIER: 1,
+        SPAWN_WAVE: {
+            INTERVAL: 1,
+            MAX_HEIGHT: 10,
+            MAX_WIDTH: 8,
+            MAX_WAVES: 10,
+            PATTERNS_PER_WAVE: 2
+        },
+        JUNK_FREQUENCY_RANGE: {
+            lower: 3,
+            upper: 5
+        },
+        SCORE_LIMIT: 100
+    },
+    {
+        LEVEL: 4,
         HEALTH_MULTIPLIER: 1.5,
         SPAWN_WAVE: {
             INTERVAL: 0.75,

--- a/source/TurretTrashbot.js
+++ b/source/TurretTrashbot.js
@@ -2,6 +2,7 @@ var Victor = require("victor")
 import Trashbot from "./Trashbot.js"
 import Reference from "./Reference.js"
 import Projectile from "./Projectile.js"
+import Utility from "./Utility.js"
 
 export default class TurretTrashbot extends Trashbot {
     constructor(position, shootStyle) {
@@ -12,7 +13,7 @@ export default class TurretTrashbot extends Trashbot {
             PIXI.loader.resources.turretTrashbot.texture)
         this.movement = Trashbot.MovementStrategy.MOVE_TO_POSITION
         this.shoot = (shootStyle === undefined) ? Trashbot.ShootStrategy.INTERVAL : shootStyle
-        this.bullets = 2
+        this.bullets = Utility.randomNumber(1,2)
         this.bulletSpeed = 1.8
     }
 


### PR DESCRIPTION
Closes #75, Closes #78, Closes #32 
- Sped up junkership and junkership slow bullet speed.
- Increased junk spawn rate. May increase this further. A super-fast pace feels good with this game.
- Added additional difficulty levels.
- Added right bumper and right trigger as viable fire keys.
- Changed junkership spawn location.

Subjective update: losing now feels like it's my own fault, rather than the game getting too hard too fast. Nice.

Build is at https://mocsarcade.github.io/starjunk/84
